### PR TITLE
Add a var to select the SSL policy for ELB Listerners

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ module "ecs_apps" {
 | alb | Whether to deploy an ALB or not with the cluster | `bool` | `true` | no |
 | alb\_internal | Deploys a second internal ALB for private APIs | `bool` | `false` | no |
 | alb\_only | Whether to deploy only an alb and no cloudFront or not with the cluster | `bool` | `false` | no |
+| alb\_ssl_policy | Select a SSL policy for the ALB Listener | `string` | `ELBSecurityPolicy-2016-08` | no |
 | asg\_max | Max number of instances for autoscaling group | `number` | `4` | no |
 | asg\_memory\_target | Target average memory percentage to track for autoscaling | `number` | `60` | no |
 | asg\_min | Min number of instances for autoscaling group | `number` | `1` | no |

--- a/_variables.tf
+++ b/_variables.tf
@@ -75,6 +75,11 @@ variable "alb_internal" {
   description = "Deploys a second internal ALB for private APIs"
 }
 
+variable "alb_ssl_policy" {
+  default     = "ELBSecurityPolicy-2016-08"
+  description = "Select a SSL policy for the ALB Listener"
+}
+
 variable "asg_min" {
   default     = 1
   description = "Min number of instances for autoscaling group"

--- a/_variables.tf
+++ b/_variables.tf
@@ -77,7 +77,8 @@ variable "alb_internal" {
 
 variable "alb_ssl_policy" {
   default     = "ELBSecurityPolicy-2016-08"
-  description = "Select a SSL policy for the ALB Listener"
+  type        = string
+  description = "The name of the SSL Policy for the listener. Required if protocol is HTTPS or TLS."
 }
 
 variable "asg_min" {

--- a/alb.tf
+++ b/alb.tf
@@ -33,7 +33,7 @@ resource "aws_lb_listener" "ecs_https" {
   load_balancer_arn = aws_lb.ecs[0].arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  ssl_policy        = var.alb_ssl_policy
   certificate_arn   = var.certificate_arn
 
   default_action {
@@ -66,7 +66,7 @@ resource "aws_lb_listener" "ecs_test_https" {
   load_balancer_arn = aws_lb.ecs[0].arn
   port              = "8443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  ssl_policy        = var.alb_ssl_policy
   certificate_arn   = var.certificate_arn
 
   default_action {


### PR DESCRIPTION
Currently, the aws_lb_listener is provisioned using the default SSL policy `"ELBSecurityPolicy-2016-08"` for HTTPS Listeners. Adding this var we can select the desired policy, but it still setting `ELBSecurityPolicy-2016-08` as the default policy.

```
variable "alb_ssl_policy" {
  default     = "ELBSecurityPolicy-2016-08"
  description = "Select a SSL policy for the ALB Listener"
}
```