### PR TITLE
Certificate ARN for internal ALB

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -75,6 +75,11 @@ variable "alb_internal" {
   description = "Deploys a second internal ALB for private APIs"
 }
 
+variable "certificate_internal_arn" {
+  default     = ""
+  description = "certificate arn for internal ALB."
+}
+
 variable "alb_ssl_policy" {
   default     = "ELBSecurityPolicy-2016-08"
   type        = string

--- a/alb-internal.tf
+++ b/alb-internal.tf
@@ -34,7 +34,7 @@ resource "aws_lb_listener" "ecs_https_internal" {
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = var.certificate_arn
+  certificate_arn   = var.certificate_internal_arn != "" ? var.certificate_internal_arn : var.certificate_arn
 
   default_action {
     type             = "forward"
@@ -49,7 +49,7 @@ resource "aws_lb_listener" "ecs_test_https_internal" {
   port              = "8443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = var.certificate_arn
+  certificate_arn   = var.certificate_internal_arn != "" ? var.certificate_internal_arn : var.certificate_arn
 
   default_action {
     type = "forward"


### PR DESCRIPTION
Certificate ARN for internal ALB if the domain is different than internet facing ALB.
If same as internet facing ALB continue using same cert.