### PR TITLE
Replace WAF classic by WAF V2 managed rule groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ module "ecs_apps" {
 | Name | Description |
 |------|-------------|
 | alb\_arn | n/a |
-| alb\_cloudfront\_key | n/a |
 | alb\_dns\_name | n/a |
 | alb\_id | n/a |
 | alb\_internal\_arn | n/a |

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ module "ecs_apps" {
 | throughput\_mode | Throughput mode for the file system. Defaults to bursting. Valid values: bursting, provisioned. | `string` | `"bursting"` | no |
 | userdata | Extra commands to pass to userdata. | `string` | `""` | no |
 | vpc\_id | VPC ID to deploy the ECS cluster. | `any` | n/a | yes |
+| wafv2_enable | Enable WAF V2 with managed rule groups. | `bool` | `false` | no |
+| wafv2_managed_rule_groups | List of AWS managed rule groups implemented with WAF V2. | `list(string)` | `["AWSManagedRulesCommonRuleSet"]` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ module "ecs_apps" {
 
 <!--- END_TF_DOCS --->
 
+## WAF V2 Managed rule groups
+
+The official documentation with the list of groups and individual rules is available here: (https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-list.html).
+
+By default, only the Core rule set (a.k.a Common rules) is deployed with WAF, if you want to customise and add more managed groups to the Web ACL you can find the list of groups expected by Terraform following this developer guide: (https://docs.aws.amazon.com/waf/latest/developerguide/waf-using-managed-rule-groups.html).
+
 ## Authors
 
 Module managed by [DNX Solutions](https://github.com/DNXLabs).

--- a/_outputs.tf
+++ b/_outputs.tf
@@ -89,7 +89,3 @@ output "ecs_nodes_secgrp_id" {
 output "alb_secgrp_id" {
   value = aws_security_group.alb.*.id
 }
-
-output "alb_cloudfront_key" {
-  value = random_string.alb_cloudfront_key.result
-}

--- a/_variables.tf
+++ b/_variables.tf
@@ -233,3 +233,14 @@ variable "kms_key_arn" {
   description = "ARN of a KMS Key to use on EFS and EBS volumes"
   default     = ""
 }
+
+variable "wafv2_enable" {
+  default     = false
+  description = "Deploys WAF V2 with Managed rule groups"
+}
+
+variable "wafv2_managed_rule_groups" {
+  type        = list(string)
+  default     = ["AWSManagedRulesCommonRuleSet"]
+  description = "List of WAF V2 managed rule groups"
+}

--- a/example/ecs-app.tf
+++ b/example/ecs-app.tf
@@ -14,7 +14,6 @@ module "ecs_app_wordpress_01" {
   hostname_origin        = "wp01-origin.labs.dnx.host" # signed by alb_certificate_arn
   hosted_zone            = "labs.dnx.host"
   certificate_arn        = local.workspace["cf_certificate_arn"] # goes on cloudfront
-  alb_cloudfront_key     = module.ecs_apps.alb_cloudfront_key
 
   # use these values for Wordpress
   healthcheck_path                          = "/readme.html"

--- a/example/ecs-cluster.tf
+++ b/example/ecs-cluster.tf
@@ -1,6 +1,6 @@
 module "ecs_apps" {
   source               = "git::https://github.com/DNXLabs/terraform-aws-ecs.git?ref=0.2.0"
-  name                 = "${local.workspace["cluster_name"]}"
+  name                 = local.workspace["cluster_name"]
   instance_type_1      = "t3.large"
   instance_type_2      = "t2.large"
   instance_type_3      = "m2.xlarge"

--- a/waf.tf
+++ b/waf.tf
@@ -1,64 +1,52 @@
-resource "aws_wafregional_web_acl_association" "alb" {
-  count = var.alb && ! var.alb_only ? 1 : 0
-
-  resource_arn = aws_lb.ecs[0].arn
-  web_acl_id   = aws_wafregional_web_acl.alb[0].id
-}
-
-resource "aws_wafregional_web_acl" "alb" {
-  count = var.alb && ! var.alb_only ? 1 : 0
-
-  depends_on  = [aws_wafregional_rule.alb_header]
-  name        = "alb_ecs_${var.name}"
-  metric_name = replace(format("alb_ecs_%s", var.name), "/[^a-zA-Z0-9]/", "")
+resource "aws_wafv2_web_acl" "alb" {
+  count       = var.alb && var.wafv2_enable ? 1 : 0
+  name        = "waf-${var.name}-web-application"
+  description = "WAF managed rules for web applications"
+  scope       = "REGIONAL"
 
   default_action {
-    type = "ALLOW"
+    allow {}
   }
 
-  rule {
-    action {
-      type = "BLOCK"
-    }
+  dynamic "rule" {
+    for_each = var.wafv2_managed_rule_groups
 
-    priority = 1
-    rule_id  = aws_wafregional_rule.alb_header[0].id
-    type     = "REGULAR"
-  }
-}
+    content {
+      name     = "waf-${var.name}-${rule.value}"
+      priority = rule.key
 
-resource "aws_wafregional_rule" "alb_header" {
-  count = var.alb && ! var.alb_only ? 1 : 0
+      override_action {
+        count {}
+      }
 
-  depends_on  = [aws_wafregional_byte_match_set.alb_header]
-  name        = "alb_cloudfront_header_ecs_${var.name}"
-  metric_name = replace(format("alb_cloudfront_header_ecs_%s", var.name), "/[^a-zA-Z0-9]/", "")
+      statement {
+        managed_rule_group_statement {
+          name        = rule.value
+          vendor_name = "AWS"
+        }
+      }
 
-  predicate {
-    data_id = aws_wafregional_byte_match_set.alb_header[0].id
-    negated = true
-    type    = "ByteMatch"
-  }
-}
-
-resource "random_string" "alb_cloudfront_key" {
-  length  = 50
-  special = false
-}
-
-resource "aws_wafregional_byte_match_set" "alb_header" {
-  count = var.alb && ! var.alb_only ? 1 : 0
-
-  name = "alb_cloudfront_header_ecs_${var.name}"
-
-  byte_match_tuples {
-    text_transformation   = "NONE"
-    target_string         = random_string.alb_cloudfront_key.result
-    positional_constraint = "EXACTLY"
-
-    field_to_match {
-      type = "HEADER"
-      data = "fromcloudfront"
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "waf-${var.name}-${rule.value}"
+        sampled_requests_enabled   = false
+      }
     }
   }
+
+  tags = {
+    Name = "waf-${var.name}-web-application"
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "waf-${var.name}-general"
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "brighte_waf_alb" {
+  count        = var.alb && var.wafv2_enable ? 1 : 0
+  resource_arn = aws_lb.ecs[0].arn
+  web_acl_arn  = aws_wafv2_web_acl.alb[0].arn
 }

--- a/waf.tf
+++ b/waf.tf
@@ -1,4 +1,4 @@
-resource "aws_wafv2_web_acl" "alb" {
+resource "aws_wafv2_web_acl" "waf_alb" {
   count       = var.alb && var.wafv2_enable ? 1 : 0
   name        = "waf-${var.name}-web-application"
   description = "WAF managed rules for web applications"
@@ -45,8 +45,8 @@ resource "aws_wafv2_web_acl" "alb" {
   }
 }
 
-resource "aws_wafv2_web_acl_association" "brighte_waf_alb" {
+resource "aws_wafv2_web_acl_association" "waf_alb_association" {
   count        = var.alb && var.wafv2_enable ? 1 : 0
   resource_arn = aws_lb.ecs[0].arn
-  web_acl_arn  = aws_wafv2_web_acl.alb[0].arn
+  web_acl_arn  = aws_wafv2_web_acl.waf_alb[0].arn
 }


### PR DESCRIPTION
## Objective

Replace WAF classic rules (which was deprecated and obsolete) by WAF V2 managed rule groups.

The cost of implementation of managed rules are way cheaper compared to custom rules and they cover already most part of the web apps scenarios like common attacks, SQL injection, PHP and Linux vulnerabilities, etc.

## Current status

The terraform code is ready for review and the default configuration enables only the **Core Rule Set (a.k.a Common Rules)** but we can activate additional groups in the default deployment, the user also has the ability of selecting additional groups via input variable.

**Core Rule Set = AWSManagedRulesCommonRuleSet**

Two new input variables were included to enable the WAF deployment and select the groups that must be implemented in the Web ACL, both of the variables have default values assigned. The WAF deployment is disabled by default.

The code in the `waf.tf` file was completed replaced and an output variable called `alb_cloudfront_key` was deleted since it wasn't used anymore and it was part of the original content from WAF classic resources.

## Improvements

At the moment we provide the ability of selecting different managed groups but in the future we could explore the option of excluding specific rules of a group using the statement **exclude_rules**.