### PR TITLE
Include option to create or not iam service linked role

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -238,3 +238,9 @@ variable "wafv2_managed_rule_groups" {
   default     = ["AWSManagedRulesCommonRuleSet"]
   description = "List of WAF V2 managed rule groups"
 }
+
+variable "create_iam_service_linked_role" {
+  type        = bool
+  default     = false
+  description = "Create iam_service_linked_role for ECS or not."
+}

--- a/iam-ecs.tf
+++ b/iam-ecs.tf
@@ -1,3 +1,8 @@
+resource "aws_iam_service_linked_role" "ecs" {
+  count = var.create_iam_service_linked_role ? 1 : 0
+  aws_service_name = "ecs.amazonaws.com"
+}
+
 resource "aws_iam_instance_profile" "ecs" {
   name = "ecs-${var.name}-${data.aws_region.current.name}"
   role = aws_iam_role.ecs.name


### PR DESCRIPTION
There is no way to determine in Terraform whether the role linked to the service has already been created in the AWS account.
So, you must manually check and, if it not exists, set **create_iam_service_linked_role** to true, otherwise, set it to false or leave as default.
We haven't found a better way to do this.