### PR TITLE
Capacity rebalance

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -305,3 +305,10 @@ variable "create_efs" {
   default     = true
   description = "Enables creation of EFS volume for cluster"
 }
+
+
+variable "asg_capacity_rebalance" {
+  type        = bool
+  default     = false
+  description = "Indicates whether capacity rebalance is enabled"
+}

--- a/asg.tf
+++ b/asg.tf
@@ -29,6 +29,8 @@ resource "aws_autoscaling_group" "ecs" {
   min_size = var.asg_min
   max_size = var.asg_max
 
+  capacity_rebalance = var.asg_capacity_rebalance
+
   protect_from_scale_in = var.asg_protect_from_scale_in
 
   tag {

--- a/ec2-launch-template.tf
+++ b/ec2-launch-template.tf
@@ -13,7 +13,7 @@ resource "aws_launch_template" "ecs" {
   count         = var.fargate_only ? 0 : 1
   name_prefix   = "ecs-${var.name}-"
   image_id      = data.aws_ami.amzn.image_id
-  instance_type = var.instance_types[0]
+  instance_type = length(var.instance_types) == 0 ? "t2.micro" : var.instance_types[0]
 
   iam_instance_profile {
     name = aws_iam_instance_profile.ecs[0].name


### PR DESCRIPTION
Add option to enable capacity rebalance on auto scaling groups

## Types of changes

What types of changes does your code introduce to terraform-aws-ecs?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

Amazon EC2 Auto Scaling is aware of EC2 instance rebalance recommendation notifications. The Amazon EC2 Spot service emits these notifications when Spot Instances are at elevated risk of interruption. When Capacity Rebalancing is enabled for an Auto Scaling group, Amazon EC2 Auto Scaling attempts to proactively replace Spot Instances in the group that have received a rebalance recommendation, providing the opportunity to rebalance your workload to new Spot Instances that are not at elevated risk of interruption. This means that your workload can continue to process the work while Amazon EC2 Auto Scaling launches a new Spot Instance before an existing instance is interrupted.