### PR TITLE
Feature/efs lifecycle policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ module "ecs_apps" {
 | create\_efs | Enables creation of EFS volume for cluster | `bool` | `true` | no |
 | create\_iam\_service\_linked\_role | Create iam\_service\_linked\_role for ECS or not. | `bool` | `false` | no |
 | ec2\_key\_enabled | Generate a SSH private key and include in launch template of ECS nodes | `bool` | `false` | no |
+| efs\_lifecycle\_transition\_to\_ia | Option to enable EFS Lifecycle Transaction to IA | `string` | `""` | no |
+| efs\_lifecycle\_transition\_to\_primary\_storage\_class | Option to enable EFS Lifecycle Transaction to Primary Storage Class | `bool` | `false` | no |
 | enable\_schedule | Enables schedule to shut down and start up instances outside business hours. | `bool` | `false` | no |
 | extra\_certificate\_arns | Extra ACM certificates to add to ALB Listeners | `list(string)` | `[]` | no |
 | fargate\_only | Enable when cluster is only for fargate and does not require ASG/EC2/EFS infrastructure | `bool` | `false` | no |

--- a/_variables.tf
+++ b/_variables.tf
@@ -323,9 +323,12 @@ variable "create_efs" {
   description = "Enables creation of EFS volume for cluster"
 }
 
-
 variable "asg_capacity_rebalance" {
   type        = bool
   default     = false
   description = "Indicates whether capacity rebalance is enabled"
+}
+
+variable "efs_lifecycle_policy" {
+  description = "Enable EFS Lifecycle configuration"
 }

--- a/_variables.tf
+++ b/_variables.tf
@@ -330,8 +330,8 @@ variable "asg_capacity_rebalance" {
 }
 
 variable "efs_lifecycle_transition_to_ia" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Option to enable EFS Lifecycle Transaction to IA"
 
   validation {
@@ -341,7 +341,7 @@ variable "efs_lifecycle_transition_to_ia" {
 }
 
 variable "efs_lifecycle_transition_to_primary_storage_class" {
-  type = bool
-  default = false
+  type        = bool
+  default     = false
   description = "Option to enable EFS Lifecycle Transaction to Primary Storage Class"
 }

--- a/_variables.tf
+++ b/_variables.tf
@@ -329,11 +329,19 @@ variable "asg_capacity_rebalance" {
   description = "Indicates whether capacity rebalance is enabled"
 }
 
-variable "efs_lifecycle_policy" {
-  type = object(({
-    enabled = bool
-    transition_to_ia = string
-    transition_to_primary_storage_class = string
-  }))
-  description = "Enable EFS Lifecycle configuration"
+variable "efs_lifecycle_transition_to_ia" {
+  type = string
+  default = ""
+  description = "Option to enable EFS Lifecycle Transaction to IA"
+
+  validation {
+    condition     = contains(["AFTER_7_DAYS", "AFTER_14_DAYS", "AFTER_30_DAYS", "AFTER_60_DAYS", "AFTER_90_DAYS", ""], var.efs_lifecycle_transition_to_ia)
+    error_message = "Indicates how long it takes to transition files to the IA storage class. Valid values: AFTER_7_DAYS, AFTER_14_DAYS, AFTER_30_DAYS, AFTER_60_DAYS, AFTER_90_DAYS. Or leave empty if not used."
+  }
+}
+
+variable "efs_lifecycle_transition_to_primary_storage_class" {
+  type = bool
+  default = false
+  description = "Option to enable EFS Lifecycle Transaction to Primary Storage Class"
 }

--- a/_variables.tf
+++ b/_variables.tf
@@ -330,5 +330,10 @@ variable "asg_capacity_rebalance" {
 }
 
 variable "efs_lifecycle_policy" {
+  type = object(({
+    enabled = bool
+    transition_to_ia = string
+    transition_to_primary_storage_class = string
+  }))
   description = "Enable EFS Lifecycle configuration"
 }

--- a/efs.tf
+++ b/efs.tf
@@ -8,16 +8,16 @@ resource "aws_efs_file_system" "ecs" {
   provisioned_throughput_in_mibps = var.provisioned_throughput_in_mibps
 
   dynamic "lifecycle_policy" {
-    for_each = var.efs_lifecycle_policy["enabled"] ? [1] : []
+    for_each = var.efs_lifecycle_transition_to_ia != "" ? [1] : []
     content {
-      transition_to_ia = var.efs_lifecycle_policy["transition_to_ia"]
+      transition_to_ia = var.efs_lifecycle_transition_to_ia
     }
   }
 
   dynamic "lifecycle_policy" {
-    for_each = var.efs_lifecycle_policy["enabled"] ? [1] : []
+    for_each = var.efs_lifecycle_transition_to_primary_storage_class ? [1] : []
     content {
-      transition_to_primary_storage_class = var.efs_lifecycle_policy["transition_to_primary_storage_class"]
+      transition_to_primary_storage_class = "AFTER_1_ACCESS"
     }
   }
 

--- a/efs.tf
+++ b/efs.tf
@@ -7,6 +7,20 @@ resource "aws_efs_file_system" "ecs" {
   throughput_mode                 = var.throughput_mode
   provisioned_throughput_in_mibps = var.provisioned_throughput_in_mibps
 
+  dynamic "lifecycle_policy" {
+    for_each = var.efs_lifecycle_policy["enabled"] ? [1] : []
+    content {
+      transition_to_ia = var.efs_lifecycle_policy["transition_to_ia"]
+    }
+  }
+
+  dynamic "lifecycle_policy" {
+    for_each = var.efs_lifecycle_policy["enabled"] ? [1] : []
+    content {
+      transition_to_primary_storage_class = var.efs_lifecycle_policy["transition_to_primary_storage_class"]
+    }
+  }
+
   tags = {
     Name   = "ecs-${var.name}"
     Backup = var.backup


### PR DESCRIPTION
Enable use of EFS Lifecycle policy.

We had a client who would like to use this feature. This feature will allow us to create a policy to transition to the Infrequent Access tier and another from Infrequent Access to primary storage.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the CONTRIBUTING.md doc.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

The **transaction_to_ia** argument support only specific values: `AFTER_7_DAYS, AFTER_14_DAYS, AFTER_30_DAYS, AFTER_60_DAYS, or AFTER_90_DAYS`. And **transition_to_primary_storage_class** (Optional), support only the value `AFTER_1_ACCESS` when enable.

The transaction_to_ia argument variable uses a validation block to check whether it has the correct value.