### PR TITLE
cluster settings deprecation fix

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -1,12 +1,6 @@
 resource "aws_ecs_cluster" "ecs" {
   name = var.name
 
-  capacity_providers = compact([
-    try(aws_ecs_capacity_provider.ecs_capacity_provider[0].name, ""),
-    "FARGATE",
-    "FARGATE_SPOT"
-  ])
-
   setting {
     name  = "containerInsights"
     value = var.container_insights ? "enabled" : "disabled"
@@ -17,5 +11,14 @@ resource "aws_ecs_cluster" "ecs" {
       tags
     ]
   }
+}
 
+resource "aws_ecs_cluster_capacity_providers" "ecs" {
+  cluster_name = aws_ecs_cluster.ecs.name
+
+  capacity_providers = compact([
+    try(aws_ecs_capacity_provider.ecs_capacity_provider[0].name, ""),
+    "FARGATE",
+    "FARGATE_SPOT"
+  ])
 }


### PR DESCRIPTION
Deprecation warning fix - move to aws_ecs_cluster_capacity_providers setting as inline is deprecated.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.
