### PR TITLE
Block Public Access to ALB

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -100,6 +100,11 @@ variable "alb_sg_allow_api_gateway" {
   description = "Whether to allow API Gateway IP range to access"
 }
 
+variable "alb_sg_allow_api_gateway_region" {
+  default     = ""
+  description = "Use this region to allow API Gateway IP range"
+}
+
 variable "alb_sg_allow_egress_https_world" {
   default     = true
   description = "Whether to allow ALB to access HTTPS endpoints - needed when using OIDC authentication"

--- a/_variables.tf
+++ b/_variables.tf
@@ -96,12 +96,12 @@ variable "alb_additional_sg" {
 }
 
 variable "alb_sg_allow_cloudfront" {
-  default     = true
+  default     = false
   description = "Whether to allow Cloudfront IP range to access"
 }
 
 variable "alb_sg_allow_api_gateway" {
-  default     = true
+  default     = false
   description = "Whether to allow API Gateway IP range to access"
 }
 

--- a/_variables.tf
+++ b/_variables.tf
@@ -90,6 +90,16 @@ variable "alb_sg_allow_test_listener" {
   description = "Whether to allow world access to the test listeners"
 }
 
+variable "alb_sg_allow_cloudfront" {
+  default     = true
+  description = "Whether to allow Cloudfront IP range to access"
+}
+
+variable "alb_sg_allow_api_gateway" {
+  default     = true
+  description = "Whether to allow API Gateway IP range to access"
+}
+
 variable "alb_sg_allow_egress_https_world" {
   default     = true
   description = "Whether to allow ALB to access HTTPS endpoints - needed when using OIDC authentication"

--- a/_variables.tf
+++ b/_variables.tf
@@ -90,6 +90,11 @@ variable "alb_sg_allow_test_listener" {
   description = "Whether to allow world access to the test listeners"
 }
 
+variable "alb_sg_custom_cidr_blocks" {
+  default     = ["0.0.0.0/0"]
+  description = "Block public access to ALB and stick to these CIDR blocks only"
+}
+
 variable "alb_additional_sg" {
   default     = []
   description = "pass addition list of security groups to add to ALB"

--- a/_variables.tf
+++ b/_variables.tf
@@ -90,6 +90,11 @@ variable "alb_sg_allow_test_listener" {
   description = "Whether to allow world access to the test listeners"
 }
 
+variable "alb_additional_sg" {
+  default     = []
+  description = "pass addition list of security groups to add to ALB"
+}
+
 variable "alb_sg_allow_cloudfront" {
   default     = true
   description = "Whether to allow Cloudfront IP range to access"

--- a/alb.tf
+++ b/alb.tf
@@ -9,6 +9,7 @@ resource "aws_lb" "ecs" {
   enable_deletion_protection = var.alb_enable_deletion_protection
 
   security_groups = compact(
+    try(var.alb_additional_sg,[]),
     concat(try(aws_security_group.from_cloudfront.*.id, []), [
     aws_security_group.alb[0].id,
     try(aws_security_group.from_api_gateway[0].id, "")

--- a/alb.tf
+++ b/alb.tf
@@ -8,11 +8,11 @@ resource "aws_lb" "ecs" {
   drop_invalid_header_fields = var.alb_drop_invalid_header_fields
   enable_deletion_protection = var.alb_enable_deletion_protection
 
-  security_groups = compact([
+  security_groups = compact(
+    concat(try(aws_security_group.from_cloudfront.*.id, []), [
     aws_security_group.alb[0].id,
-    try(aws_security_group.from_cloudfront[0].id, ""),
     try(aws_security_group.from_api_gateway[0].id, "")
-  ])
+  ]))
 
   idle_timeout = 400
 

--- a/alb.tf
+++ b/alb.tf
@@ -8,9 +8,11 @@ resource "aws_lb" "ecs" {
   drop_invalid_header_fields = var.alb_drop_invalid_header_fields
   enable_deletion_protection = var.alb_enable_deletion_protection
 
-  security_groups = [
+  security_groups = compact([
     aws_security_group.alb[0].id,
-  ]
+    try(aws_security_group.from_cloudfront[0].id, ""),
+    try(aws_security_group.from_api_gateway[0].id, "")
+  ])
 
   idle_timeout = 400
 

--- a/alb.tf
+++ b/alb.tf
@@ -9,9 +9,9 @@ resource "aws_lb" "ecs" {
   enable_deletion_protection = var.alb_enable_deletion_protection
 
   security_groups = compact(
+    concat(try(aws_security_group.from_cloudfront.*.id, []), 
     try(var.alb_additional_sg,[]),
-    concat(try(aws_security_group.from_cloudfront.*.id, []), [
-    aws_security_group.alb[0].id,
+    [ aws_security_group.alb[0].id,
     try(aws_security_group.from_api_gateway[0].id, "")
   ]))
 

--- a/sg-alb.tf
+++ b/sg-alb.tf
@@ -31,7 +31,7 @@ resource "aws_security_group_rule" "https_from_world_to_alb" {
   to_port           = 443
   protocol          = "tcp"
   security_group_id = aws_security_group.alb[0].id
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = var.alb_sg_custom_cidr_blocks
 }
 
 resource "aws_security_group_rule" "https_test_listener_from_world_to_alb" {
@@ -43,7 +43,7 @@ resource "aws_security_group_rule" "https_test_listener_from_world_to_alb" {
   to_port           = 8443
   protocol          = "tcp"
   security_group_id = aws_security_group.alb[0].id
-  cidr_blocks       = ["0.0.0.0/0"]
+  cidr_blocks       = var.alb_sg_custom_cidr_blocks
 }
 
 

--- a/sg-aws-iprange.tf
+++ b/sg-aws-iprange.tf
@@ -1,0 +1,47 @@
+data "aws_ip_ranges" "cloudfront" {
+  services = ["cloudfront"]
+}
+
+data "aws_ip_ranges" "api_gateway" {
+  services = ["api_gateway"]
+}
+
+resource "aws_security_group" "from_cloudfront" {
+  count = var.alb && var.alb_sg_allow_cloudfront ? 1 : 0
+  name = "from-cloudfront-${var.name}"
+  description = "SG for Request from Cloudfront"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port        = "443"
+    to_port          = "443"
+    protocol         = "tcp"
+    cidr_blocks      = data.aws_ip_ranges.cloudfront.cidr_blocks
+  }
+
+  tags = {
+    Name = "from-cloudfront-${var.name}"
+    CreateDate = data.aws_ip_ranges.cloudfront.create_date
+    SyncToken  = data.aws_ip_ranges.cloudfront.sync_token
+  }
+}
+
+resource "aws_security_group" "from_api_gateway" {
+  count = var.alb && var.alb_sg_allow_api_gateway ? 1 : 0
+  name = "from-api-gateway-${var.name}"
+  description = "SG for Request from API Gateway"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port        = "443"
+    to_port          = "443"
+    protocol         = "tcp"
+    cidr_blocks      = data.aws_ip_ranges.api_gateway.cidr_blocks
+  }
+
+  tags = {
+    Name = "from-api-gateway-${var.name}"
+    CreateDate = data.aws_ip_ranges.api_gateway.create_date
+    SyncToken  = data.aws_ip_ranges.api_gateway.sync_token
+  }
+}

--- a/sg-aws-iprange.tf
+++ b/sg-aws-iprange.tf
@@ -31,8 +31,10 @@ resource "aws_security_group" "from_cloudfront" {
 
   tags = {
     Name = "from-cloudfront-${var.name}-${count.index}"
-    CreateDate = data.aws_ip_ranges.cloudfront.create_date
-    SyncToken  = data.aws_ip_ranges.cloudfront.sync_token
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 
@@ -51,7 +53,9 @@ resource "aws_security_group" "from_api_gateway" {
 
   tags = {
     Name = "from-api-gateway-${var.name}"
-    CreateDate = data.aws_ip_ranges.api_gateway.create_date
-    SyncToken  = data.aws_ip_ranges.api_gateway.sync_token
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }

--- a/sg-aws-iprange.tf
+++ b/sg-aws-iprange.tf
@@ -1,26 +1,36 @@
 data "aws_ip_ranges" "cloudfront" {
+  regions  = ["global"]
   services = ["cloudfront"]
 }
 
 data "aws_ip_ranges" "api_gateway" {
+  regions  = compact([data.aws_region.current.name,try(var.alb_sg_allow_api_gateway_region, "")])
   services = ["api_gateway"]
 }
 
+locals {
+  ip_chunks = chunklist(data.aws_ip_ranges.cloudfront.cidr_blocks, 50)
+}
+
 resource "aws_security_group" "from_cloudfront" {
-  count = var.alb && var.alb_sg_allow_cloudfront ? 1 : 0
-  name = "from-cloudfront-${var.name}"
+  count = var.alb && var.alb_sg_allow_cloudfront ? length(local.ip_chunks) : 0
+  name = "from-cloudfront-${var.name}-${count.index}"
   description = "SG for Request from Cloudfront"
   vpc_id      = var.vpc_id
 
-  ingress {
-    from_port        = "443"
-    to_port          = "443"
-    protocol         = "tcp"
-    cidr_blocks      = data.aws_ip_ranges.cloudfront.cidr_blocks
+  dynamic "ingress" {
+    for_each = local.ip_chunks[count.index]
+
+    content {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
   }
 
   tags = {
-    Name = "from-cloudfront-${var.name}"
+    Name = "from-cloudfront-${var.name}-${count.index}"
     CreateDate = data.aws_ip_ranges.cloudfront.create_date
     SyncToken  = data.aws_ip_ranges.cloudfront.sync_token
   }


### PR DESCRIPTION
This change support using a custom CIDR range for ALB, so you can block public access while still being able to use most of the scenarios. 

- Use alb_sg_custom_cidr_blocks to override 0.0.0.0 with a list of IP range you want to allow
- You can use the option alb_sg_allow_cloudfront to create security group from aws_ip_ranges
- You can use alb_sg_allow_api_gateway to allow API gateway requests from the same region
- You can use alb_sg_allow_api_gateway_region to pass additional API regions
- You can use alb_additional_sg to pass additional security groups 

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the CONTRIBUTING.md doc.
- [ ] I have added the necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...