### PR TITLE
fix: define container_insights as an enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ module "ecs_apps" {
 | certificate\_arn | n/a | `any` | n/a | yes |
 | certificate\_internal\_arn | certificate arn for internal ALB. | `string` | `""` | no |
 | code\_deploy | Enables CodeDeploy role to be used for deployment | `bool` | `true` | no |
-| container\_insights | Enables CloudWatch Container Insights for a cluster. | `bool` | `false` | no |
+| container\_insights | Enables CloudWatch Container Insights for a cluster. | `string` | `"disabled"` | no |
 | create\_efs | Enables creation of EFS volume for cluster | `bool` | `true` | no |
 | create\_iam\_service\_linked\_role | Create iam\_service\_linked\_role for ECS or not. | `bool` | `false` | no |
 | ebs\_key\_arn | ARN of a KMS Key to use on EBS volumes | `string` | `""` | no |

--- a/_variables.tf
+++ b/_variables.tf
@@ -368,9 +368,13 @@ variable "extra_task_policies_arn" {
 }
 
 variable "container_insights" {
-  type        = bool
-  default     = false
+  type        = string
+  default     = "disabled"
   description = "Enables CloudWatch Container Insights for a cluster."
+  validation {
+    condition = contains(["enhanced", "enabled", "disabled"], var.container_insights)
+    error_message = "Container Insights must be one of: enhanced, enabled, disabled."
+  }
 }
 
 variable "alb_test_listener" {

--- a/ecs.tf
+++ b/ecs.tf
@@ -3,7 +3,7 @@ resource "aws_ecs_cluster" "ecs" {
 
   setting {
     name  = "containerInsights"
-    value = var.container_insights ? "enabled" : "disabled"
+    value = var.container_insights
   }
 
   tags = merge(
@@ -13,7 +13,7 @@ resource "aws_ecs_cluster" "ecs" {
     },
   )
   lifecycle {
-    ignore_changes = []
+    ignore_changes = [service_connect_defaults]
     
   }
 }


### PR DESCRIPTION
Define `setting.container_insights.value` as an enum. 
Resource [aws_ecs_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster#setting-block)

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the CONTRIBUTING.md doc.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...