### PR TITLE
DNX-37997 add ALB client IP controls

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,10 +50,12 @@ jobs:
   minimum:
     name: Minimum version check
     runs-on: ubuntu-latest
-    container:
-      image: hashicorp/terraform:0.13.0
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 0.13.0
+          terraform_wrapper: false
       - name: Validate Code
         env:
           AWS_REGION: 'us-east-1'

--- a/README.md
+++ b/README.md
@@ -73,13 +73,18 @@ module "ecs_apps" {
 | alb | Whether to deploy an ALB or not with the cluster. | `bool` | `true` | no |
 | alb\_drop\_invalid\_header\_fields | Indicates whether HTTP headers with invalid header fields are removed by the load balancer (true) or routed to targets (false). | `bool` | `true` | no |
 | alb\_enable\_deletion\_protection | Enable deletion protection for ALBs | `bool` | `false` | no |
+| alb\_enable\_xff\_client\_port | Whether the external ALB preserves the client source port in X-Forwarded-For. | `bool` | `false` | no |
 | alb\_http\_listener | Whether to enable HTTP listeners | `bool` | `true` | no |
 | alb\_internal | Deploys a second internal ALB for private APIs. | `bool` | `false` | no |
 | alb\_internal\_ssl\_policy | The name of the SSL Policy for the listener. Required if protocol is HTTPS or TLS. | `string` | `"ELBSecurityPolicy-TLS-1-2-Ext-2018-06"` | no |
 | alb\_only | Whether to deploy only an alb and no cloudFront or not with the cluster. | `bool` | `false` | no |
 | alb\_sg\_allow\_egress\_https\_world | Whether to allow ALB to access HTTPS endpoints - needed when using OIDC authentication | `bool` | `true` | no |
+| alb\_sg\_allow\_https\_world | Whether to allow world access to the external ALB HTTPS listener on port 443. | `bool` | `true` | no |
 | alb\_sg\_allow\_test\_listener | Whether to allow world access to the test listeners | `bool` | `true` | no |
+| alb\_sg\_https\_prefix\_list\_ids | Managed prefix list IDs allowed to reach the external ALB HTTPS listener on port 443. | `list(string)` | `[]` | no |
+| alb\_sg\_test\_listener\_cidr\_blocks | Additional CIDR blocks allowed to reach the external ALB test listener on port 8443. | `list(string)` | `[]` | no |
 | alb\_ssl\_policy | The name of the SSL Policy for the listener. Required if protocol is HTTPS or TLS. | `string` | `"ELBSecurityPolicy-2016-08"` | no |
+| alb\_xff\_header\_processing\_mode | How the external ALB processes X-Forwarded-For before forwarding to targets. | `string` | `"append"` | no |
 | architecture | Architecture to select the AMI, x86\_64 or arm64 | `string` | `"x86_64"` | no |
 | asg\_capacity\_rebalance | Indicates whether capacity rebalance is enabled | `bool` | `false` | no |
 | asg\_max | Max number of instances for autoscaling group. | `number` | `4` | no |

--- a/_variables.tf
+++ b/_variables.tf
@@ -90,6 +90,24 @@ variable "alb_sg_allow_test_listener" {
   description = "Whether to allow world access to the test listeners"
 }
 
+variable "alb_sg_allow_https_world" {
+  default     = true
+  type        = bool
+  description = "Whether to allow world access to the external ALB HTTPS listener on port 443."
+}
+
+variable "alb_sg_https_prefix_list_ids" {
+  default     = []
+  type        = list(string)
+  description = "Managed prefix list IDs allowed to reach the external ALB HTTPS listener on port 443."
+}
+
+variable "alb_sg_test_listener_cidr_blocks" {
+  default     = []
+  type        = list(string)
+  description = "Additional CIDR blocks allowed to reach the external ALB test listener on port 8443."
+}
+
 variable "alb_sg_allow_egress_https_world" {
   default     = true
   description = "Whether to allow ALB to access HTTPS endpoints - needed when using OIDC authentication"
@@ -119,6 +137,23 @@ variable "alb_ssl_policy" {
   default     = "ELBSecurityPolicy-2016-08"
   type        = string
   description = "The name of the SSL Policy for the listener. Required if protocol is HTTPS or TLS."
+}
+
+variable "alb_xff_header_processing_mode" {
+  default     = "append"
+  type        = string
+  description = "How the external ALB processes X-Forwarded-For before forwarding to targets."
+
+  validation {
+    condition     = contains(["append", "preserve", "remove"], var.alb_xff_header_processing_mode)
+    error_message = "alb_xff_header_processing_mode must be append, preserve, or remove."
+  }
+}
+
+variable "alb_enable_xff_client_port" {
+  default     = false
+  type        = bool
+  description = "Whether the external ALB preserves the client source port in X-Forwarded-For."
 }
 
 variable "alb_internal_ssl_policy" {

--- a/_variables.tf
+++ b/_variables.tf
@@ -146,7 +146,7 @@ variable "alb_xff_header_processing_mode" {
 
   validation {
     condition     = contains(["append", "preserve", "remove"], var.alb_xff_header_processing_mode)
-    error_message = "alb_xff_header_processing_mode must be append, preserve, or remove."
+    error_message = "The alb_xff_header_processing_mode value must be append, preserve, or remove."
   }
 }
 

--- a/alb.tf
+++ b/alb.tf
@@ -7,6 +7,8 @@ resource "aws_lb" "ecs" {
   subnets                    = var.public_subnet_ids
   drop_invalid_header_fields = var.alb_drop_invalid_header_fields
   enable_deletion_protection = var.alb_enable_deletion_protection
+  xff_header_processing_mode = var.alb_xff_header_processing_mode
+  enable_xff_client_port     = var.alb_enable_xff_client_port
 
   security_groups = [
     aws_security_group.alb[0].id,

--- a/sg-alb.tf
+++ b/sg-alb.tf
@@ -23,7 +23,7 @@ resource "aws_security_group_rule" "http_from_world_to_alb" {
 }
 
 resource "aws_security_group_rule" "https_from_world_to_alb" {
-  count = var.alb ? 1 : 0
+  count = var.alb && var.alb_sg_allow_https_world ? 1 : 0
 
   description       = "HTTPS ECS ALB"
   type              = "ingress"
@@ -32,6 +32,18 @@ resource "aws_security_group_rule" "https_from_world_to_alb" {
   protocol          = "tcp"
   security_group_id = aws_security_group.alb[0].id
   cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "https_from_prefix_lists_to_alb" {
+  count = var.alb && length(var.alb_sg_https_prefix_list_ids) > 0 ? 1 : 0
+
+  description       = "HTTPS ECS ALB from managed prefix lists"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.alb[0].id
+  prefix_list_ids   = var.alb_sg_https_prefix_list_ids
 }
 
 resource "aws_security_group_rule" "https_test_listener_from_world_to_alb" {
@@ -44,6 +56,18 @@ resource "aws_security_group_rule" "https_test_listener_from_world_to_alb" {
   protocol          = "tcp"
   security_group_id = aws_security_group.alb[0].id
   cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "https_test_listener_from_cidrs_to_alb" {
+  count = var.alb && length(var.alb_sg_test_listener_cidr_blocks) > 0 ? 1 : 0
+
+  description       = "HTTPS ECS ALB Test Listener from approved CIDRs"
+  type              = "ingress"
+  from_port         = 8443
+  to_port           = 8443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.alb[0].id
+  cidr_blocks       = var.alb_sg_test_listener_cidr_blocks
 }
 
 


### PR DESCRIPTION
## Summary

Adds backward-compatible controls to the terraform-aws-ecs 6.8 maintenance line for:

- ALB X-Forwarded-For processing mode
- ALB XFF client-port preservation
- CloudFront managed prefix-list access to port 443
- Approved CIDR access to the port 8443 test listener

## Compatibility

Existing defaults are preserved:

- Port 443 remains world-accessible unless explicitly disabled.
- Port 8443 retains the existing alb_sg_allow_test_listener behaviour.
- XFF processing remains append by default.
- XFF client-port preservation remains disabled by default.

No resource names or Terraform addresses are changed.