### PR TITLE
Force IMDSv2 on ECS launch template

### DIFF
--- a/ec2-launch-template.tf
+++ b/ec2-launch-template.tf
@@ -19,6 +19,11 @@ resource "aws_launch_template" "ecs" {
     }
   }
 
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
   vpc_security_group_ids = concat([aws_security_group.ecs_nodes.id], var.security_group_ids)
 
   user_data = base64encode(templatefile("${path.module}/userdata.tpl", {


### PR DESCRIPTION
Closes #29.

Adds `metadata_options { http_tokens = "required" }` to the launch template so IMDSv2 is enforced. `checkov`'s `CKV_AWS_79` now passes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

Ran `terraform validate` and `checkov` before/after: `CKV_AWS_79` goes failed → passed, nothing else regresses.

Two heads-up for reviewers:
- No `instance_refresh` on the ASG, so existing instances only get IMDSv2 once naturally replaced.
- Containers hitting the instance metadata endpoint directly in bridge/host mode may need `http_put_response_hop_limit = 2` — didn't add it since the issue only asked for `http_tokens`.